### PR TITLE
57 edit user accounts

### DIFF
--- a/frontend/scss/style.scss
+++ b/frontend/scss/style.scss
@@ -158,3 +158,9 @@ h1.splash-header {
 	background: linear-gradient(to bottom, rgba(234,234,234,1) 8%,rgba(175,175,175,1) 95%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#eaeaea', endColorstr='#afafaf',GradientType=0 ); /* IE6-9 */
 }
+
+/* Forms */
+.neutral-feedback {
+	color: tint($body-color, 30%);
+	font-size: .8rem;
+}

--- a/setup-scripts/01-CreateAndSeedTables.py
+++ b/setup-scripts/01-CreateAndSeedTables.py
@@ -1,9 +1,10 @@
 import psycopg2
 import sys
 import bcrypt
+import os
 
-table_creation_succeeded = True
-user_creation_succeeded = True
+admin_role_id = 1
+standard_role_id = 2
 
 conn_string = "host='localhost' dbname='ChoreExplore' user='cxp' password='choresarereallyfun'"
 
@@ -131,8 +132,8 @@ def seed_admin_user():
 		INSERT INTO users
 			(id, role_id, username, password, first_name, middle_name, last_name, email_address, date_of_birth, points)
 			VALUES
-			(1, 1, 'administrator', '%s', 'first', 'middle', 'last', 'test@email.com', TO_DATE('01 Jan 1945', 'DD Mon YYYY'), 0)
-		""" % (encrypted_password)
+			(1, {0}, 'administrator', '{1}', 'first', 'middle', 'last', 'test@email.com', TO_DATE('01 Jan 1945', 'DD Mon YYYY'), 0)
+		""".format(admin_role_id, (encrypted_password))
 	]
 
 	if(execute_commands(commands)):

--- a/src/User.py
+++ b/src/User.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from app import db
 import bcrypt
+from app import app
 from BaseMixin import BaseMixin
-
 
 class User(BaseMixin, db.Model):
     __tablename__ = 'users'
@@ -49,7 +49,7 @@ class User(BaseMixin, db.Model):
         self.password = User.EncryptPassword(self.password)
 
         # Default to standard role, start with 0 points
-        self.role_id = 1
+        self.role_id = app.config["STANDARD_ROLE_ID"]
         self.points = 0
 
         db.session.add(self)

--- a/src/User.py
+++ b/src/User.py
@@ -75,6 +75,15 @@ class User(BaseMixin, db.Model):
                 return True
         return False
 
+    def UpdateData(self):
+        """ Update a user """
+        # If we aren't updating the password, make sure it doesn't change
+        if self.password == None:
+            self.password = self.GetHashedPassword()
+
+        db.session.commit()
+        return True
+
     # Delete operations
 
     # Utility operations
@@ -94,7 +103,12 @@ class User(BaseMixin, db.Model):
         else:
             return False
 
-    # Add Points
+    def GetHashedPassword(self):
+        """ Get a hashed password from the db """
+        return User.query.filter_by(id=self.id).first().password
+
+
+
     def AddPoints(self, points):
         """ Add a chore's points to the user account """
         self.points += points

--- a/src/User.py
+++ b/src/User.py
@@ -80,6 +80,9 @@ class User(BaseMixin, db.Model):
         # If we aren't updating the password, make sure it doesn't change
         if self.password == None:
             self.password = self.GetHashedPassword()
+        # Otherwise, encrypt the new one
+        else:
+            self.password = User.EncryptPassword(self.password)
 
         db.session.commit()
         return True
@@ -106,8 +109,6 @@ class User(BaseMixin, db.Model):
     def GetHashedPassword(self):
         """ Get a hashed password from the db """
         return User.query.filter_by(id=self.id).first().password
-
-
 
     def AddPoints(self, points):
         """ Add a chore's points to the user account """

--- a/src/app.py
+++ b/src/app.py
@@ -26,6 +26,7 @@ app = Flask(__name__, static_url_path='/static')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = CREDS['SQLALCHEMY_TRACK_MODIFICATIONS']
 app.config['SQLALCHEMY_DATABASE_URI'] = CREDS['SQLALCHEMY_DATABASE_URI']
 app.config['ADMIN_ROLE_ID'] = CREDS['ADMIN_ROLE_ID']
+app.config['STANDARD_ROLE_ID'] = CREDS['STANDARD_ROLE_ID']
 
 db = SQLAlchemy(app)
 
@@ -349,6 +350,9 @@ def user_edit(user_id=None):
     errors=None
     old_user = User.User.GetById(user_id)
 
+    loggedInUserId = session['user_id']
+    loggedInUserRoleId = session['role_id']
+
     # Check for user editing self (allowed) or admin editing anyone (also allowed)
     if old_user.id == session['user_id'] or session['role_id'] == app.config['ADMIN_ROLE_ID']:
         if request.method == 'GET':
@@ -377,7 +381,7 @@ def user_edit(user_id=None):
                 _log(1, VERBOSITY, 'edited user: {}'.format(old_user.username))
                 flash('Success: User edited', category='success')
 
-                return (redirect(url_for('user')))
+                return (redirect(url_for('index')))
 
             else:
                 _log(1, VERBOSITY, 'form has errors: {}'.format(form.errors))
@@ -389,7 +393,7 @@ def user_edit(user_id=None):
     else:
         _log(1, VERBOSITY, 'user attempted to edit an account without permission')
         flash('Error: You may not edit other user accounts unless you are an administrator', category='danger')
-        return redirect(url_for('user'))
+        return redirect(url_for('index'))
 
 # Chore routes
 

--- a/src/app.py
+++ b/src/app.py
@@ -354,13 +354,13 @@ def user_edit(user_id=None):
         if request.method == 'GET':
             form = UserEditForm()
 
-            form.username = old_user.username
-            form.password = None
-            form.email_address = old_user.email_address
-            form.first_name = old_user.first_name
-            form.middle_name = old_user.middle_name
-            form.last_name = old_user.last_name
-            form.date_of_birth = old_user.date_of_birth
+            form.username.data = old_user.username
+            form.password.data = None
+            form.email_address.data = old_user.email_address
+            form.first_name.data = old_user.first_name
+            form.middle_name.data = old_user.middle_name
+            form.last_name.data = old_user.last_name
+            form.date_of_birth.data = old_user.date_of_birth
 
         if request.method == 'POST':
             form = UserEditForm(request.form)
@@ -377,7 +377,7 @@ def user_edit(user_id=None):
                 _log(1, VERBOSITY, 'edited user: {}'.format(old_user.username))
                 flash('Success: User edited', category='success')
 
-                return (redirect(url_for('users')))
+                return (redirect(url_for('user')))
 
             else:
                 _log(1, VERBOSITY, 'form has errors: {}'.format(form.errors))

--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,8 @@ def get_now():
 
 def get_creds(path, crypt=False):
     ret_dict = { 
-                "ADMIN_ROLE_ID": 0,
+                "ADMIN_ROLE_ID": 1,
+                "STANDARD_ROLE_ID": 2,
                 "SECRET_KEY": "I am a secret key", 
                 "CSRF_ENABLED": True, 
                 "SQLALCHEMY_DATABASE_URI": "postgresql://cxp:choresarereallyfun@localhost/ChoreExplore", 

--- a/src/envs.json
+++ b/src/envs.json
@@ -1,5 +1,6 @@
 {
 	"ADMIN_ROLE_ID": 1,
+	"STANDARD_ROLE_ID": 2,
 	"SECRET_KEY": "I am a secret key",
 	"CSRF_ENABLED": true,
 	"SQLALCHEMY_DATABASE_URI": "postgresql://cxp:choresarereallyfun@localhost/ChoreExplore",

--- a/src/templates/user_edit.html
+++ b/src/templates/user_edit.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block content %}
+    {% if errors %}
+        {% for error in errors: %}
+            {{error}}<br>
+        {% endfor %}
+    {% endif %}
+
+    <form action="{{ url_for('user_edit', user_id=user.id) }}" method="post">
+        {{ form.hidden_tag() }}
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.username.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.username(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.password.label }}
+                <br>
+                <span class="neutral-feedback">Note: Only enter a password if you want to change it</span>
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.password(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.email_address.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.email_address(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.first_name.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.first_name(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.middle_name.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.middle_name(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.last_name.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.last_name(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {{ form.date_of_birth.label }}
+            </div>
+            <div class="form-group col-md-6">
+                {{ form.date_of_birth(class_="form-control mb-2 mr-sm-2") }}
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-12 text-center">
+                <button class="btn btn-primary" type="submit">Edit User</button>
+            </div>
+        </div>
+    </form>
+{% endblock %}


### PR DESCRIPTION
Fixes #57. Allows editing own and other (if admin) user accounts.

I feel like this satisfies (at least in the prototype) the requirement for the ability to reset passwords. We could make it a standalone function at some point, but I don't know if it's worth the time/effort. I think this is fine.

I don't have the user (admin or standard) verifying the new password. It would be an easy change though if we really want to add it.