### PR TITLE
#86 - Added username/email uniqueness check when editing user account

### DIFF
--- a/src/templates/user_edit.html
+++ b/src/templates/user_edit.html
@@ -9,7 +9,7 @@
 
 {% if user.id == session['user_id'] %}
 <div class="alert alert-info">
-	If you edit your own account, you will need to log in again
+	Notice: If you edit your own account, you will need to log in again
 </div>
 <br>
 {% endif %}


### PR DESCRIPTION
Fixes #86. Added a uniquness check to the user_edit route.

Sidenote: I don't like having all of this logic in the routes, but I prefer putting it there at this point just to avoid reworking the documentation we have already submitted. :man_facepalming: